### PR TITLE
CI-883 - Reduce number of claims being stored

### DIFF
--- a/src/SFA.DAS.Forecasting.Web/Startup.cs
+++ b/src/SFA.DAS.Forecasting.Web/Startup.cs
@@ -115,17 +115,10 @@ namespace SFA.DAS.Forecasting.Web
         {
             logger.Info("PostAuthenticationAction called");
             var userRef = identity.Claims.FirstOrDefault(claim => claim.Type == constants.Id())?.Value;
-            var email = identity.Claims.FirstOrDefault(claim => claim.Type == constants.Email())?.Value;
-            var firstName = identity.Claims.FirstOrDefault(claim => claim.Type == constants.GivenName())?.Value;
-            var lastName = identity.Claims.FirstOrDefault(claim => claim.Type == constants.FamilyName())?.Value;
-            logger.Info("Claims retrieved from OIDC server {0}: {1} : {2} : {3}", userRef, email, firstName, lastName);
+            logger.Info("Claims retrieved from OIDC server for user {0}", userRef);
 
-            identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, identity.Claims.First(c => c.Type == constants.Id()).Value));
-            identity.AddClaim(new Claim(ClaimTypes.Name, identity.Claims.First(c => c.Type == constants.DisplayName()).Value));
             identity.AddClaim(new Claim("sub", identity.Claims.First(c => c.Type == constants.Id()).Value));
-            identity.AddClaim(new Claim("email", identity.Claims.First(c => c.Type == constants.Email()).Value));
-
-            //HttpContext.Current.Response.Redirect(HttpContext.Current.Request.Path, true);
+            
         }
 
         private static StartupConfiguration GetConfigurationObject()


### PR DESCRIPTION
Reduce number of claims being stored to reduce the cookie size. Sub is
the only that should be required.

I have investigated this, attempting to reproduce it locally - however have been unable to. On further investigation and before implementing a mechanism to store the other claims, its not needed as we don't use anything other than sub.