### PR TITLE
CI-926 Include TransferInCompletionPayments for future funds

### DIFF
--- a/src/SFA.DAS.Forecasting.Domain.UnitTests/Projection/AccountProjectionTests.cs
+++ b/src/SFA.DAS.Forecasting.Domain.UnitTests/Projection/AccountProjectionTests.cs
@@ -6,11 +6,8 @@ using FluentAssertions;
 using NUnit.Framework;
 using SFA.DAS.Forecasting.Core;
 using SFA.DAS.Forecasting.Domain.Commitments;
-using SFA.DAS.Forecasting.Domain.Commitments.Validation;
-using SFA.DAS.Forecasting.Domain.Events;
 using SFA.DAS.Forecasting.Models.Balance;
 using SFA.DAS.Forecasting.Models.Commitments;
-using SFA.DAS.Forecasting.Models.Projections;
 
 namespace SFA.DAS.Forecasting.Domain.UnitTests.Projection
 {
@@ -251,5 +248,130 @@ namespace SFA.DAS.Forecasting.Domain.UnitTests.Projection
             accountProjection.Projections.Skip(1).First().FutureFunds
                 .Should().Be(expected);
         }
+
+        [Test]
+        public void Then_The_Receiving_Employer_FutureFunds_Does_Not_Change_With_Only_Transfers_In()
+        {
+            //Arrange
+            _account = new Account(1, 200, 0, 0, 0);
+            Moqer.SetInstance(_account);
+            _commitments.LevyFundedCommitments = new List<CommitmentModel>();
+            _commitments.SendingEmployerTransferCommitments = new List<CommitmentModel>();
+            _commitments.ReceivingEmployerTransferCommitments = new List<CommitmentModel>
+            {
+                new CommitmentModel
+                {
+                    EmployerAccountId = 999,
+                    SendingEmployerAccountId = 1,
+                    ApprenticeshipId = 23,
+                    LearnerId = 33,
+                    StartDate = DateTime.Today,
+                    PlannedEndDate = DateTime.Today.GetStartOfMonth().AddMonths(6),
+                    MonthlyInstallment = 2000,
+                    NumberOfInstallments = 6,
+                    CompletionAmount = 1200,
+                    FundingSource = Models.Payments.FundingSource.Transfer
+                }
+            };
+            var employerCommitments = new EmployerCommitments(1, _commitments);
+            Moqer.SetInstance(employerCommitments);
+            var accountProjection = Moqer.Resolve<Projections.AccountProjection>();
+            
+            //Act
+            accountProjection.BuildPayrollPeriodEndTriggeredProjections(DateTime.Today, 12);
+
+            //Assert
+            Assert.IsTrue(accountProjection.Projections.All(c => c.FutureFunds == 200));
+        }
+
+        [Test]
+        public void Then_When_You_Are_A_Sending_Employer_Your_FutureFunds_Are_Updated()
+        {
+            //Arrange
+            _account = new Account(1, 2000, 0, 0, 0);
+            Moqer.SetInstance(_account);
+            _commitments.LevyFundedCommitments = new List<CommitmentModel>();
+            _commitments.ReceivingEmployerTransferCommitments = new List<CommitmentModel>();
+            _commitments.SendingEmployerTransferCommitments = new List<CommitmentModel>
+            {
+                new CommitmentModel
+                {
+                    EmployerAccountId = 1,
+                    SendingEmployerAccountId = 999,
+                    ApprenticeshipId = 23,
+                    LearnerId = 33,
+                    StartDate = DateTime.Today,
+                    PlannedEndDate = DateTime.Today.GetStartOfMonth().AddMonths(6),
+                    MonthlyInstallment = 100,
+                    NumberOfInstallments = 6,
+                    CompletionAmount = 400,
+                    FundingSource = Models.Payments.FundingSource.Transfer
+                }
+            };
+
+            var employerCommitments = new EmployerCommitments(1, _commitments);
+            Moqer.SetInstance(employerCommitments);
+
+            var accountProjection = Moqer.Resolve<Projections.AccountProjection>();
+
+            accountProjection.BuildPayrollPeriodEndTriggeredProjections(DateTime.Today, 12);
+
+            //Assert
+            Assert.AreEqual(1000m,accountProjection.Projections[7].FutureFunds);
+            Assert.AreEqual(1000m,accountProjection.Projections.Last().FutureFunds);
+        }
+
+        [Test]
+        public void Then_If_I_Am_A_Sending_And_Receiving_Employer_My_Funds_Are_Updated()
+        {
+            //Arrange
+            _account = new Account(1, 2000, 0, 0, 0);
+            Moqer.SetInstance(_account);
+            _commitments.LevyFundedCommitments = new List<CommitmentModel>();
+            _commitments.ReceivingEmployerTransferCommitments = new List<CommitmentModel>
+            {
+                new CommitmentModel
+                {
+                    EmployerAccountId = 999,
+                    SendingEmployerAccountId = 1,
+                    ApprenticeshipId = 23,
+                    LearnerId = 33,
+                    StartDate = DateTime.Today,
+                    PlannedEndDate = DateTime.Today.GetStartOfMonth().AddMonths(6),
+                    MonthlyInstallment = 2000,
+                    NumberOfInstallments = 6,
+                    CompletionAmount = 1200,
+                    FundingSource = Models.Payments.FundingSource.Transfer
+                }
+            };
+            _commitments.SendingEmployerTransferCommitments = new List<CommitmentModel>
+            {
+                new CommitmentModel
+                {
+                    EmployerAccountId = 1,
+                    SendingEmployerAccountId = 999,
+                    ApprenticeshipId = 23,
+                    LearnerId = 33,
+                    StartDate = DateTime.Today,
+                    PlannedEndDate = DateTime.Today.GetStartOfMonth().AddMonths(6),
+                    MonthlyInstallment = 100,
+                    NumberOfInstallments = 6,
+                    CompletionAmount = 400,
+                    FundingSource = Models.Payments.FundingSource.Transfer
+                }
+            };
+
+            var employerCommitments = new EmployerCommitments(1, _commitments);
+            Moqer.SetInstance(employerCommitments);
+
+            var accountProjection = Moqer.Resolve<Projections.AccountProjection>();
+
+            accountProjection.BuildPayrollPeriodEndTriggeredProjections(DateTime.Today, 12);
+
+            //Assert
+            Assert.AreEqual(1000m, accountProjection.Projections[7].FutureFunds);
+            Assert.AreEqual(1000m, accountProjection.Projections.Last().FutureFunds);
+        }
+
     }
 }

--- a/src/SFA.DAS.Forecasting.Domain/Projections/AccountProjection.cs
+++ b/src/SFA.DAS.Forecasting.Domain/Projections/AccountProjection.cs
@@ -61,8 +61,8 @@ namespace SFA.DAS.Forecasting.Domain.Projections
             var totalCostOfTraning = _employerCommitments.GetTotalCostOfTraining(period);
             var completionPayments = _employerCommitments.GetTotalCompletionPayments(period);
             
-            var costOfTraining = totalCostOfTraning.LevyFunded + totalCostOfTraning.TransferOut;            
-            var complPayment = completionPayments.LevyFundedCompletionPayment + completionPayments.TransferOutCompletionPayment;
+            var costOfTraining = totalCostOfTraning.LevyFunded + totalCostOfTraning.TransferOut;
+            var complPayment = completionPayments.LevyFundedCompletionPayment + (completionPayments.TransferOutCompletionPayment - completionPayments.TransferInCompletionPayment);
 
             var moneyOut = ignoreCostOfTraining ? 0 : costOfTraining + complPayment;
             var moneyIn = lastBalance + levyFundsIn + totalCostOfTraning.TransferIn;


### PR DESCRIPTION
Change so that the completionPayments now takes into account the
TransferInCompletionPayments, so these are deducted from the
TransferOutCompletionPayments so the funds are not altered when
projecting a receiving funds account