### PR TITLE
CI-951 - Revert ignoreCostOfTraining logic

### DIFF
--- a/src/SFA.DAS.Forecasting.AcceptanceTests/Projections/Feature/Calculate co-investment amounts.feature
+++ b/src/SFA.DAS.Forecasting.AcceptanceTests/Projections/Feature/Calculate co-investment amounts.feature
@@ -22,6 +22,24 @@ Scenario: Calculate co-investment after payment run with positive balance
 	And the employer co-investment amount is 10% of the remaining cost of training
 	And the government co-investment amount is 90% of the remaining cost of training
 
+Scenario: Calculate co-investment after payment run with positive balance and affordable commitment
+	Given I'm a levy paying employer
+	And the payroll period is 
+	| Payroll Year | Payroll Month |
+	| 18-19        | 1             |
+	And the following levy declarations have been recorded
+	| Scheme   | Amount | Created Date |
+	| ABC-1234 | 400   | Today        |
+	And the current balance is 300
+	And the following commitments have been recorded
+	| Apprentice Name | Course Name | Course Level | Provider Name | Start Date | Installment Amount | Completion Amount | Number Of Installments | FundingSource |
+	| Test Apprentice | Test Course | 1            | Test Provider | last month  | 200               | 300              | 6                      | CoInvestedSfa |
+	When the account projection is triggered after a payment run
+	Then the account projection should be generated
+	And the balance should be 700
+	And the co-investment amount is zero
+
+
 Scenario: Calculate co-investment after payment run with negative balance
 	Given I'm a levy paying employer
 	And the payroll period is 

--- a/src/SFA.DAS.Forecasting.AcceptanceTests/Projections/Feature/Calculate co-investment amounts.feature.cs
+++ b/src/SFA.DAS.Forecasting.AcceptanceTests/Projections/Feature/Calculate co-investment amounts.feature.cs
@@ -134,10 +134,12 @@ this.ScenarioSetup(scenarioInfo);
         }
         
         [NUnit.Framework.TestAttribute()]
-        [NUnit.Framework.DescriptionAttribute("Calculate co-investment after payment run with negative balance")]
-        public virtual void CalculateCo_InvestmentAfterPaymentRunWithNegativeBalance()
+        [NUnit.Framework.DescriptionAttribute("Calculate co-investment after payment run with positive balance and affordable co" +
+            "mmitment")]
+        public virtual void CalculateCo_InvestmentAfterPaymentRunWithPositiveBalanceAndAffordableCommitment()
         {
-            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Calculate co-investment after payment run with negative balance", ((string[])(null)));
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Calculate co-investment after payment run with positive balance and affordable co" +
+                    "mmitment", ((string[])(null)));
 #line 25
 this.ScenarioSetup(scenarioInfo);
 #line 26
@@ -163,7 +165,7 @@ this.ScenarioSetup(scenarioInfo);
 #line 30
  testRunner.And("the following levy declarations have been recorded", ((string)(null)), table5, "And ");
 #line 33
- testRunner.And("the current balance is -300", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+ testRunner.And("the current balance is 300", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             TechTalk.SpecFlow.Table table6 = new TechTalk.SpecFlow.Table(new string[] {
                         "Apprentice Name",
@@ -181,8 +183,8 @@ this.ScenarioSetup(scenarioInfo);
                         "1",
                         "Test Provider",
                         "last month",
-                        "600",
-                        "700",
+                        "200",
+                        "300",
                         "6",
                         "CoInvestedSfa"});
 #line 34
@@ -192,10 +194,76 @@ this.ScenarioSetup(scenarioInfo);
 #line 38
  testRunner.Then("the account projection should be generated", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line 39
- testRunner.And("the balance should be 100", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+ testRunner.And("the balance should be 700", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 40
+ testRunner.And("the co-investment amount is zero", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Calculate co-investment after payment run with negative balance")]
+        public virtual void CalculateCo_InvestmentAfterPaymentRunWithNegativeBalance()
+        {
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Calculate co-investment after payment run with negative balance", ((string[])(null)));
+#line 43
+this.ScenarioSetup(scenarioInfo);
+#line 44
+ testRunner.Given("I\'m a levy paying employer", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+            TechTalk.SpecFlow.Table table7 = new TechTalk.SpecFlow.Table(new string[] {
+                        "Payroll Year",
+                        "Payroll Month"});
+            table7.AddRow(new string[] {
+                        "18-19",
+                        "1"});
+#line 45
+ testRunner.And("the payroll period is", ((string)(null)), table7, "And ");
+#line hidden
+            TechTalk.SpecFlow.Table table8 = new TechTalk.SpecFlow.Table(new string[] {
+                        "Scheme",
+                        "Amount",
+                        "Created Date"});
+            table8.AddRow(new string[] {
+                        "ABC-1234",
+                        "400",
+                        "Today"});
+#line 48
+ testRunner.And("the following levy declarations have been recorded", ((string)(null)), table8, "And ");
+#line 51
+ testRunner.And("the current balance is -300", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            TechTalk.SpecFlow.Table table9 = new TechTalk.SpecFlow.Table(new string[] {
+                        "Apprentice Name",
+                        "Course Name",
+                        "Course Level",
+                        "Provider Name",
+                        "Start Date",
+                        "Installment Amount",
+                        "Completion Amount",
+                        "Number Of Installments",
+                        "FundingSource"});
+            table9.AddRow(new string[] {
+                        "Test Apprentice",
+                        "Test Course",
+                        "1",
+                        "Test Provider",
+                        "last month",
+                        "600",
+                        "700",
+                        "6",
+                        "CoInvestedSfa"});
+#line 52
+ testRunner.And("the following commitments have been recorded", ((string)(null)), table9, "And ");
+#line 55
+ testRunner.When("the account projection is triggered after a payment run", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 56
+ testRunner.Then("the account projection should be generated", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 57
+ testRunner.And("the balance should be 100", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 58
  testRunner.And("the employer co-investment amount is 10% of the remaining cost of training", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 41
+#line 59
  testRunner.And("the government co-investment amount is 90% of the remaining cost of training", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             this.ScenarioCleanup();

--- a/src/SFA.DAS.Forecasting.AcceptanceTests/Projections/Steps/CalculateCo_InvestmentAmountsCI_570Steps.cs
+++ b/src/SFA.DAS.Forecasting.AcceptanceTests/Projections/Steps/CalculateCo_InvestmentAmountsCI_570Steps.cs
@@ -28,6 +28,16 @@ namespace SFA.DAS.Forecasting.AcceptanceTests.Projections.Steps
 
             projection.FutureFunds.Should().Be(p0);
         }
+        [Then(@"the co-investment amount is zero")]
+        public void ThenTheCo_InvestmentAmountIsZero()
+        {
+            var projection = AccountProjections
+                .OrderBy(m => m.Year)
+                .ThenBy(m => m.Month)
+                .First();
+
+            Assert.AreEqual(0, projection.CoInvestmentEmployer + projection.CoInvestmentGovernment);
+        }
 
         [Then(@"the employer co-investment amount is 10% of the remaining cost of training")]
         public void ThenTheEmployerCo_InvestmentAmountIsOfTheNegativeBalance()

--- a/src/SFA.DAS.Forecasting.Domain.UnitTests/Projection/AccountProjectionTests.cs
+++ b/src/SFA.DAS.Forecasting.Domain.UnitTests/Projection/AccountProjectionTests.cs
@@ -234,7 +234,7 @@ namespace SFA.DAS.Forecasting.Domain.UnitTests.Projection
             accountProjection.BuildPayrollPeriodEndTriggeredProjections(DateTime.Today, 2);
 
             accountProjection.Projections.First().FutureFunds
-                .Should().Be(_account.Balance + _account.LevyDeclared - _commitment.MonthlyInstallment);
+                .Should().Be(_account.Balance + _account.LevyDeclared);// - _commitment.MonthlyInstallment);
         }
 
         [Test]
@@ -251,7 +251,7 @@ namespace SFA.DAS.Forecasting.Domain.UnitTests.Projection
 
 
         [Test]
-        public void Then_The_CoInvestment_Is_Calculated_Correctly_For_The_First_Month_With_A_Postive_Balance_And_An_Affordable_Commitment()
+        public void Then_The_CoInvestment_Is_Calculated_Correctly_For_The_First_Month_With_A_Postive_Balance_And_An_Affordable_Commitment_For_Payment_Run()
         {
             //Arrange
             CreateCommitmentModel(200, 300);
@@ -267,17 +267,47 @@ namespace SFA.DAS.Forecasting.Domain.UnitTests.Projection
             var expectedMonth1 = accountProjection.Projections.FirstOrDefault();
             Assert.AreEqual(0, expectedMonth1?.CoInvestmentGovernment);
             Assert.AreEqual(0, expectedMonth1?.CoInvestmentEmployer);
-            Assert.AreEqual(500, expectedMonth1?.FutureFunds);
+            Assert.AreEqual(700, expectedMonth1?.FutureFunds);
 
             var expectedMonth2 = accountProjection.Projections.Skip(1).FirstOrDefault();
             Assert.AreEqual(0, expectedMonth2?.CoInvestmentGovernment);
             Assert.AreEqual(0, expectedMonth2?.CoInvestmentEmployer);
-            Assert.AreEqual(700, expectedMonth2?.FutureFunds);
+            Assert.AreEqual(900, expectedMonth2?.FutureFunds);
 
             var expectedMonth3 = accountProjection.Projections.Skip(2).FirstOrDefault();
             Assert.AreEqual(0, expectedMonth3?.CoInvestmentGovernment);
             Assert.AreEqual(0, expectedMonth3?.CoInvestmentEmployer);
-            Assert.AreEqual(900, expectedMonth3?.FutureFunds);
+            Assert.AreEqual(1100, expectedMonth3?.FutureFunds);
+        }
+
+        [Test]
+        public void Then_The_CoInvestment_Is_Calculated_Correctly_For_The_First_Month_With_A_Postive_Balance_And_An_Affordable_Commitment_For_Levy_Run()
+        {
+            //Arrange
+            CreateCommitmentModel(200, 300);
+
+            _account = new Account(1, 300, 400, 0, 0);
+            Moqer.SetInstance(_account);
+            var accountProjection = Moqer.Resolve<Projections.AccountProjection>();
+
+            //Act
+            accountProjection.BuildLevyTriggeredProjections(DateTime.Today, 2);
+
+            //Assert
+            var expectedMonth1 = accountProjection.Projections.FirstOrDefault();
+            Assert.AreEqual(0, expectedMonth1?.CoInvestmentGovernment);
+            Assert.AreEqual(0, expectedMonth1?.CoInvestmentEmployer);
+            Assert.AreEqual(300, expectedMonth1?.FutureFunds);
+
+            var expectedMonth2 = accountProjection.Projections.Skip(1).FirstOrDefault();
+            Assert.AreEqual(0, expectedMonth2?.CoInvestmentGovernment);
+            Assert.AreEqual(0, expectedMonth2?.CoInvestmentEmployer);
+            Assert.AreEqual(500, expectedMonth2?.FutureFunds);
+
+            var expectedMonth3 = accountProjection.Projections.Skip(2).FirstOrDefault();
+            Assert.AreEqual(0, expectedMonth3?.CoInvestmentGovernment);
+            Assert.AreEqual(0, expectedMonth3?.CoInvestmentEmployer);
+            Assert.AreEqual(700, expectedMonth3?.FutureFunds);
         }
 
         [Test]
@@ -454,7 +484,6 @@ namespace SFA.DAS.Forecasting.Domain.UnitTests.Projection
             Assert.AreEqual(1600m, accountProjection.Projections.Last().FutureFunds);
         }
 
-        
 
 		[TestCase(800, 200, 0, 400, 0, true, 200)]
 		[TestCase(400, 200, 0, 400, 0, true, 0)]

--- a/src/SFA.DAS.Forecasting.Domain/Projections/AccountProjection.cs
+++ b/src/SFA.DAS.Forecasting.Domain/Projections/AccountProjection.cs
@@ -42,7 +42,7 @@ namespace SFA.DAS.Forecasting.Domain.Projections
             {
                 var levyFundsIn = projectionGenerationType == ProjectionGenerationType.LevyDeclaration && month == startMonth
                         ? 0 : _account.LevyDeclared;
-                var ignoreCostOfTraining = projectionGenerationType == ProjectionGenerationType.LevyDeclaration && month == startMonth;
+                var ignoreCostOfTraining = month == startMonth;
 
                 var projection = CreateProjection(
                     periodStart.AddMonths(month),


### PR DESCRIPTION
Revert the ignore cost of training logic so that the cost of training
is not taken into consideration when its the first month.