### PR TITLE
Ci 967 error summary links

### DIFF
--- a/src/SFA.DAS.Forecasting.Web/Content/dist/js/screen.js
+++ b/src/SFA.DAS.Forecasting.Web/Content/dist/js/screen.js
@@ -178,3 +178,23 @@ $(window).scroll(function () {
 sfa.navigation.init();
 
 $('ul#global-nav-links').collapsableNav();
+
+$(function () {
+    $('.error-summary-with-sticky-header a').on('click touch', function (e) {
+
+        var target = $(this).prop('hash'),
+            $target = $(target);
+
+        if ($target.length === 0) {
+            return;
+        }
+
+        window.scrollTo(0, $target.offset().top - 130);
+
+        if ($target.is('input, select')) {
+            $target.focus();
+        }
+
+        e.preventDefault();
+    });
+});

--- a/src/SFA.DAS.Forecasting.Web/Views/Estimation/AddApprenticeships.cshtml
+++ b/src/SFA.DAS.Forecasting.Web/Views/Estimation/AddApprenticeships.cshtml
@@ -22,7 +22,7 @@
 
                 <p>Please check the details you have entered against the information that's needed.</p>
 
-                <ul class="error-summary-list list list-links">
+                <ul class="error-summary-list error-summary-with-sticky-header">
                     <li class="@HideShowValidation("NoApprenticeshipSelected")" id="noStandardSelected"><a href="#select2-choose-apprenticeship-container">You must choose 1 apprenticeship</a></li>
                     <li class="@HideShowValidation("NoNumberOfApprentices")" id="noNumberOfApprentices"><a href="#no-of-app">Make sure you have at least 1 or more apprentices</a></li>
                     <li class="@HideShowValidation("NoNumberOfMonths")" id="noLength"><a href="#apprenticeship-length">The number of months was not entered</a></li>

--- a/src/SFA.DAS.Forecasting.Web/Views/Estimation/AddApprenticeships.cshtml
+++ b/src/SFA.DAS.Forecasting.Web/Views/Estimation/AddApprenticeships.cshtml
@@ -9,7 +9,7 @@
 @using (@Html.BeginForm("Save", "Estimation", FormMethod.Post))
 {
     @Html.AntiForgeryToken()
-    <main id="content" role="main" tabindex="-1">
+ 
         <div id="estimate-add-apprenticeship">
             <a href="@Url.ExternalUrlAction("transfers",string.Empty,false)" class="link-back">Back to Transfers</a>
             @Html.HiddenFor(model => model.Name)
@@ -180,7 +180,7 @@
             </div>
 
         </div>
-    </main>
+
 }
 
 @functions{


### PR DESCRIPTION
- fix to ensure form fields are not hidden by the sticky header when clicking the links in the error summary 