### PR TITLE
CI-988 Index removal on commitments table

### DIFF
--- a/src/SFA.DAS.Forecasting.Application/Projections/Services/AccountProjectionDataSession.cs
+++ b/src/SFA.DAS.Forecasting.Application/Projections/Services/AccountProjectionDataSession.cs
@@ -117,10 +117,6 @@ namespace SFA.DAS.Forecasting.Application.Projections.Services
             stopwatch.Start();
             var startTime = DateTime.UtcNow;
 
-            await _dataContext.Database.ExecuteSqlCommandAsync(
-                "DELETE FROM dbo.AccountProjectionCommitment where AccountProjectionId in (SELECT id from dbo.AccountProjection where EmployerAccountId=@p0)",
-                employerAccountId);
-
             await _dataContext.Database.ExecuteSqlCommandAsync("DELETE FROM dbo.AccountProjection where EmployerAccountId=@p0", employerAccountId);
             stopwatch.Stop();
             _telemetry.TrackDependency(DependencyType.SqlDatabaseDelete, "Delete Account Projections", startTime, stopwatch.Elapsed, true);

--- a/src/SFA.DAS.Forecasting.Database/Tables/Commitment.sql
+++ b/src/SFA.DAS.Forecasting.Database/Tables/Commitment.sql
@@ -26,11 +26,7 @@ CREATE NONCLUSTERED INDEX [idx_commitment_sendingEmployerAccountId] ON [dbo].[Co
 GO
 CREATE NONCLUSTERED INDEX [idx_commitment_actualendate] ON [dbo].[Commitment] ([ActualEndDate])INCLUDE ([EmployerAccountId],[SendingEmployerAccountId],[LearnerId],[ProviderId],[ProviderName],[ApprenticeshipId],[ApprenticeName],[CourseName],[CourseLevel],[StartDate],[PlannedEndDate],[CompletionAmount],[MonthlyInstallment],[FundingSource],   [NumberOfInstallments]   ) WITH (ONLINE = ON)
 GO
-CREATE NONCLUSTERED INDEX [idx_commitment_employerAccountId_sending_endDate] ON [dbo].[commitment] ([ActualEndDate],[EmployerAccountId], [SendingEmployerAccountId] ) INCLUDE ([id],[ApprenticeName], [ApprenticeshipId], [CompletionAmount], [CourseLevel], [CourseName], [FundingSource], [LearnerId], [MonthlyInstallment], [NumberOfInstallments], [PlannedEndDate], [ProviderId], [ProviderName], [StartDate]) WHERE(ActualEndDate IS NULL) WITH (ONLINE = ON)
-GO
 CREATE NONCLUSTERED INDEX [idx_commitment_employerAccountId_fundingsource_endDate] ON [dbo].[commitment] ([ActualEndDate],[EmployerAccountId], [FundingSource] , [StartDate]) INCLUDE ([id],[ApprenticeName], [ApprenticeshipId], [CompletionAmount], [CourseLevel], [CourseName], [SendingEmployerAccountId], [LearnerId], [MonthlyInstallment], [NumberOfInstallments], [PlannedEndDate], [ProviderId], [ProviderName]) WHERE(ActualEndDate IS NULL) WITH (ONLINE = ON)
 GO
 CREATE NONCLUSTERED INDEX [idx_commitment_sendingemployerAccountId_fundingsource_endDate] ON [dbo].[commitment] ([ActualEndDate],[SendingEmployerAccountId], [FundingSource], [StartDate] ) INCLUDE ([id],[ApprenticeName], [ApprenticeshipId], [CompletionAmount], [CourseLevel], [CourseName], [EmployerAccountId], [LearnerId], [MonthlyInstallment], [NumberOfInstallments], [PlannedEndDate], [ProviderId], [ProviderName]) WHERE(ActualEndDate IS NULL) WITH (ONLINE = ON)
-GO
-CREATE NONCLUSTERED INDEX [IX_Commitment_EmployerAccountId_ApprenticeshipId_ActualEndDate] ON [dbo].[Commitment] ([EmployerAccountId], [ApprenticeshipId], [ActualEndDate]) WITH (ONLINE = ON)
 GO


### PR DESCRIPTION
Removed two indexes that arent used on the commitments table. Please
note that these need to be removed manually before running publish
database

```
IF EXISTS (select 1 from sys.indexes where name =
'IX_Commitment_EmployerAccountId_ApprenticeshipId_ActualEndDate')
BEGIN
 DROP INDEX
[IX_Commitment_EmployerAccountId_ApprenticeshipId_ActualEndDate] ON
[dbo].[Commitment]
END
GO

IF EXISTS (select 1 from sys.indexes where name =
'idx_commitment_employerAccountId_sending_endDate')
BEGIN
 DROP INDEX [idx_commitment_employerAccountId_sending_endDate] ON
[dbo].[Commitment]
END
GO
```