### PR TITLE
CI-1046 - Correct path for Apprenticeships header

### DIFF
--- a/src/SFA.DAS.Forecasting.Web/Extensions/UrlHelperExtensions.cs
+++ b/src/SFA.DAS.Forecasting.Web/Extensions/UrlHelperExtensions.cs
@@ -9,7 +9,7 @@ namespace SFA.DAS.Forecasting.Web.Extensions
 {
     public static class UrlHelperExtensions
     {
-        public static string ExternalUrlAction(this UrlHelper helper, string controllerName, string actionName = "", bool ignoreAccountId = false)
+        public static string ExternalUrlAction(this UrlHelper helper, string controllerName, string actionName = "", bool ignoreAccountId = false, string folderPath="")
         {
 
             var baseUrl = GetBaseUrl();
@@ -19,7 +19,7 @@ namespace SFA.DAS.Forecasting.Web.Extensions
             var accountId = helper.RequestContext.RouteData.Values["hashedAccountId"];
 
             return ignoreAccountId ? $"{baseUrl}{controllerName}/{actionName}"
-                                    : $"{baseUrl}accounts/{accountId}/{controllerName}/{actionName}";
+                                    : $"{baseUrl}{folderPath}accounts/{accountId}/{controllerName}/{actionName}";
 
         }
 

--- a/src/SFA.DAS.Forecasting.Web/Views/Shared/_Header.cshtml
+++ b/src/SFA.DAS.Forecasting.Web/Views/Shared/_Header.cshtml
@@ -70,7 +70,7 @@
                 <ul role="menubar" id="global-nav-links">
                     <li><a href="@Url.ExternalUrlAction("teams")" class="@(ViewBag.Section == "home" ? "selected" : "")" role="menuitem">Home</a></li>
                     <li><a href="@Url.ExternalUrlAction("balance")" class="@(ViewBag.Section == "finance" ? "selected" : "")" role="menuitem">Finance</a></li>
-                    <li><a href="@Url.ExternalUrlAction("EmployerCommitments")" class="@(ViewBag.Section == "apprentices" ? "selected" : "")" role="menuitem">Apprentices</a></li>
+                    <li><a href="@Url.ExternalUrlAction("apprentices","home",folderPath:"commitments/")" class="@(ViewBag.Section == "apprentices" ? "selected" : "")" role="menuitem">Apprentices</a></li>
                     <li><a href="@Url.ExternalUrlAction("teams", "view")" class="@(ViewBag.Section == "team" ? "selected" : "")" role="menuitem">Your team</a></li>
                     <li><a href="@Url.ExternalUrlAction("agreements")" class="@(ViewBag.Section == "organisations" ? "selected" : "")" role="menuitem">Your organisations and agreements</a></li>
                     <li><a href="@Url.ExternalUrlAction("schemes")" class="@(ViewBag.Section == "paye" ? "selected" : "")" role="menuitem">PAYE schemes</a></li>


### PR DESCRIPTION
Corrected the controller and path for the apprentices link on the
navigation bar. Also added extra parameter to set the folder so it works
correctly for commitments application.

**_Please note that this can only be tested in pre-prod due to environment setup_**