### PR TITLE
[CON-1647] Having updated the AccountApi package to use a more up to …

### DIFF
--- a/src/SFA.DAS.Forecasting.AcceptanceTests/App.config
+++ b/src/SFA.DAS.Forecasting.AcceptanceTests/App.config
@@ -45,7 +45,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.19.8.16603" newVersion="3.19.8.16603" />
+        <bindingRedirect oldVersion="0.0.0.0-3.18.0.2306" newVersion="3.18.0.2306" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="AngleSharp" publicKeyToken="e83494dcdc6d31ea" culture="neutral" />
@@ -57,7 +57,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory.Platform" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.19.8.16603" newVersion="3.19.8.16603" />
+        <bindingRedirect oldVersion="0.0.0.0-3.18.0.2306" newVersion="3.18.0.2306" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Configuration" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/src/SFA.DAS.Forecasting.AcceptanceTests/SFA.DAS.Forecasting.AcceptanceTests.csproj
+++ b/src/SFA.DAS.Forecasting.AcceptanceTests/SFA.DAS.Forecasting.AcceptanceTests.csproj
@@ -75,6 +75,12 @@
     <Reference Include="Microsoft.Data.Services.Client, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Data.Services.Client.5.8.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=3.18.0.2306, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.18.0\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.Platform, Version=3.18.0.2306, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.18.0\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\WindowsAzure.Storage.8.7.0\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
@@ -87,8 +93,14 @@
     <Reference Include="nunit.framework, Version=3.9.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.9.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
+    <Reference Include="SFA.DAS.Common.Domain, Version=1.4.278.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Common.Domain.1.4.278\lib\net462\SFA.DAS.Common.Domain.dll</HintPath>
+    </Reference>
+    <Reference Include="SFA.DAS.EAS.Account.Api.Client, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Account.Api.Client.1.6.2924\lib\net462\SFA.DAS.EAS.Account.Api.Client.dll</HintPath>
+    </Reference>
     <Reference Include="SFA.DAS.EAS.Account.Api.Types, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Account.Api.Types.1.3.1331\lib\net45\SFA.DAS.EAS.Account.Api.Types.dll</HintPath>
+      <HintPath>..\packages\SFA.DAS.Account.Api.Types.1.6.2924\lib\net462\SFA.DAS.EAS.Account.Api.Types.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.Provider.Events.Api.Client, Version=2.1.30.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Provider.Events.Api.Client.2.1.30\lib\net45\SFA.DAS.Provider.Events.Api.Client.dll</HintPath>

--- a/src/SFA.DAS.Forecasting.AcceptanceTests/packages.config
+++ b/src/SFA.DAS.Forecasting.AcceptanceTests/packages.config
@@ -11,12 +11,15 @@
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net462" />
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net462" />
   <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net462" />
+  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.18.0" targetFramework="net462" />
   <package id="Nancy" version="2.0.0-clinteastwood" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net462" />
   <package id="NUnit" version="3.9.0" targetFramework="net462" />
   <package id="NUnit.ConsoleRunner" version="3.8.0" targetFramework="net462" />
   <package id="NUnit3TestAdapter" version="3.9.0" targetFramework="net462" />
-  <package id="SFA.DAS.Account.Api.Types" version="1.3.1331" targetFramework="net462" />
+  <package id="SFA.DAS.Account.Api.Client" version="1.6.2924" targetFramework="net462" />
+  <package id="SFA.DAS.Account.Api.Types" version="1.6.2924" targetFramework="net462" />
+  <package id="SFA.DAS.Common.Domain" version="1.4.278" targetFramework="net462" />
   <package id="SFA.DAS.Provider.Events.Api.Client" version="2.1.30" targetFramework="net462" />
   <package id="SpecFlow" version="2.4.0" targetFramework="net462" />
   <package id="SpecFlow.NUnit" version="2.4.0" targetFramework="net462" />

--- a/src/SFA.DAS.Forecasting.Application.UnitTests/SFA.DAS.Forecasting.Application.UnitTests.csproj
+++ b/src/SFA.DAS.Forecasting.Application.UnitTests/SFA.DAS.Forecasting.Application.UnitTests.csproj
@@ -96,11 +96,14 @@
     <Reference Include="SFA.DAS.Apprenticeships.Api.Types, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Apprenticeships.Api.Types.0.11.98\lib\net462\SFA.DAS.Apprenticeships.Api.Types.dll</HintPath>
     </Reference>
+    <Reference Include="SFA.DAS.Common.Domain, Version=1.4.278.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Common.Domain.1.4.278\lib\net462\SFA.DAS.Common.Domain.dll</HintPath>
+    </Reference>
     <Reference Include="SFA.DAS.EAS.Account.Api.Client, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Account.Api.Client.1.3.1331\lib\net45\SFA.DAS.EAS.Account.Api.Client.dll</HintPath>
+      <HintPath>..\packages\SFA.DAS.Account.Api.Client.1.6.2924\lib\net462\SFA.DAS.EAS.Account.Api.Client.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.EAS.Account.Api.Types, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Account.Api.Types.1.3.1331\lib\net45\SFA.DAS.EAS.Account.Api.Types.dll</HintPath>
+      <HintPath>..\packages\SFA.DAS.Account.Api.Types.1.6.2924\lib\net462\SFA.DAS.EAS.Account.Api.Types.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.EmployerFinance.Types, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.EmployerFinance.Types.0.2.24\lib\netstandard2.0\SFA.DAS.EmployerFinance.Types.dll</HintPath>

--- a/src/SFA.DAS.Forecasting.Application.UnitTests/packages.config
+++ b/src/SFA.DAS.Forecasting.Application.UnitTests/packages.config
@@ -16,10 +16,11 @@
   <package id="NUnit.ConsoleRunner" version="3.8.0" targetFramework="net462" />
   <package id="NUnit3TestAdapter" version="3.9.0" targetFramework="net462" />
   <package id="Polly" version="5.1.0" targetFramework="net462" />
-  <package id="SFA.DAS.Account.Api.Client" version="1.3.1331" targetFramework="net462" />
-  <package id="SFA.DAS.Account.Api.Types" version="1.3.1331" targetFramework="net462" />
+  <package id="SFA.DAS.Account.Api.Client" version="1.6.2924" targetFramework="net462" />
+  <package id="SFA.DAS.Account.Api.Types" version="1.6.2924" targetFramework="net462" />
   <package id="SFA.DAS.Apprenticeships.Api.Client" version="0.11.98" targetFramework="net462" />
   <package id="SFA.DAS.Apprenticeships.Api.Types" version="0.11.98" targetFramework="net462" />
+  <package id="SFA.DAS.Common.Domain" version="1.4.278" targetFramework="net462" />
   <package id="SFA.DAS.EmployerFinance.Types" version="0.2.24" targetFramework="net462" />
   <package id="SFA.DAS.HashingService" version="1.0.0.57835" targetFramework="net462" />
   <package id="SFA.DAS.NLog.Logger" version="1.0.0.47445" targetFramework="net462" />

--- a/src/SFA.DAS.Forecasting.Application/SFA.DAS.Forecasting.Application.csproj
+++ b/src/SFA.DAS.Forecasting.Application/SFA.DAS.Forecasting.Application.csproj
@@ -152,8 +152,8 @@
     <Reference Include="SFA.DAS.Commitments.Api.Types, Version=4.1.494.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Commitments.Api.Types.4.1.494\lib\net462\SFA.DAS.Commitments.Api.Types.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.Common.Domain, Version=1.4.272.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Common.Domain.1.4.272\lib\net462\SFA.DAS.Common.Domain.dll</HintPath>
+    <Reference Include="SFA.DAS.Common.Domain, Version=1.4.278.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Common.Domain.1.4.278\lib\net462\SFA.DAS.Common.Domain.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.Configuration, Version=1.0.0.53229, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Configuration.1.0.0.53229\lib\net45\SFA.DAS.Configuration.dll</HintPath>
@@ -162,10 +162,10 @@
       <HintPath>..\packages\SFA.DAS.Configuration.AzureTableStorage.1.0.0.53229\lib\net45\SFA.DAS.Configuration.AzureTableStorage.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.EAS.Account.Api.Client, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Account.Api.Client.1.3.1331\lib\net45\SFA.DAS.EAS.Account.Api.Client.dll</HintPath>
+      <HintPath>..\packages\SFA.DAS.Account.Api.Client.1.6.2924\lib\net462\SFA.DAS.EAS.Account.Api.Client.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.EAS.Account.Api.Types, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Account.Api.Types.1.3.1331\lib\net45\SFA.DAS.EAS.Account.Api.Types.dll</HintPath>
+      <HintPath>..\packages\SFA.DAS.Account.Api.Types.1.6.2924\lib\net462\SFA.DAS.EAS.Account.Api.Types.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.EmployerFinance.Types, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.EmployerFinance.Types.0.2.24\lib\netstandard2.0\SFA.DAS.EmployerFinance.Types.dll</HintPath>

--- a/src/SFA.DAS.Forecasting.Application/Shared/Services/EmployerDataService.cs
+++ b/src/SFA.DAS.Forecasting.Application/Shared/Services/EmployerDataService.cs
@@ -19,7 +19,7 @@ namespace SFA.DAS.Forecasting.Application.Shared.Services
         Task<List<long>> EmployersForPeriod(string payrollYear, short payrollMonth);
     }
 
-    public class LevyDeclarations : List<LevyDeclarationViewModel>, IAccountResource { }
+    public class LevyDeclarations : List<LevyDeclarationViewModel> { }
 
     public class EmployerDataService : IEmployerDataService
     {

--- a/src/SFA.DAS.Forecasting.Application/packages.config
+++ b/src/SFA.DAS.Forecasting.Application/packages.config
@@ -33,15 +33,15 @@
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net462" />
   <package id="NLog" version="4.4.12" targetFramework="net462" />
   <package id="Polly" version="5.1.0" targetFramework="net462" />
-  <package id="SFA.DAS.Account.Api.Client" version="1.3.1331" targetFramework="net462" />
-  <package id="SFA.DAS.Account.Api.Types" version="1.3.1331" targetFramework="net462" />
+  <package id="SFA.DAS.Account.Api.Client" version="1.6.2924" targetFramework="net462" />
+  <package id="SFA.DAS.Account.Api.Types" version="1.6.2924" targetFramework="net462" />
   <package id="SFA.DAS.Apprenticeships.Api.Client" version="0.11.98" targetFramework="net462" />
   <package id="SFA.DAS.Apprenticeships.Api.Types" version="0.11.98" targetFramework="net462" />
   <package id="SFA.DAS.Authentication.Extensions.Legacy" version="1.0.22" targetFramework="net462" />
   <package id="SFA.DAS.AutoConfiguration" version="2.2.6" targetFramework="net462" />
   <package id="SFA.DAS.Commitments.Api.Client" version="4.1.494" targetFramework="net462" />
   <package id="SFA.DAS.Commitments.Api.Types" version="4.1.494" targetFramework="net462" />
-  <package id="SFA.DAS.Common.Domain" version="1.4.272" targetFramework="net462" />
+  <package id="SFA.DAS.Common.Domain" version="1.4.278" targetFramework="net462" />
   <package id="SFA.DAS.Configuration" version="1.0.0.53229" targetFramework="net462" />
   <package id="SFA.DAS.Configuration.AzureTableStorage" version="1.0.0.53229" targetFramework="net462" />
   <package id="SFA.DAS.EmployerFinance.Types" version="0.2.24" targetFramework="net462" />

--- a/src/SFA.DAS.Forecasting.Core/SFA.DAS.Forecasting.Core.csproj
+++ b/src/SFA.DAS.Forecasting.Core/SFA.DAS.Forecasting.Core.csproj
@@ -39,11 +39,14 @@
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="SFA.DAS.Common.Domain, Version=1.4.278.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Common.Domain.1.4.278\lib\net462\SFA.DAS.Common.Domain.dll</HintPath>
+    </Reference>
     <Reference Include="SFA.DAS.EAS.Account.Api.Client, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Account.Api.Client.1.3.1331\lib\net45\SFA.DAS.EAS.Account.Api.Client.dll</HintPath>
+      <HintPath>..\packages\SFA.DAS.Account.Api.Client.1.6.2924\lib\net462\SFA.DAS.EAS.Account.Api.Client.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.EAS.Account.Api.Types, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Account.Api.Types.1.3.1331\lib\net45\SFA.DAS.EAS.Account.Api.Types.dll</HintPath>
+      <HintPath>..\packages\SFA.DAS.Account.Api.Types.1.6.2924\lib\net462\SFA.DAS.EAS.Account.Api.Types.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/SFA.DAS.Forecasting.Core/packages.config
+++ b/src/SFA.DAS.Forecasting.Core/packages.config
@@ -2,8 +2,9 @@
 <packages>
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.18.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net462" />
-  <package id="SFA.DAS.Account.Api.Client" version="1.3.1331" targetFramework="net462" />
-  <package id="SFA.DAS.Account.Api.Types" version="1.3.1331" targetFramework="net462" />
+  <package id="SFA.DAS.Account.Api.Client" version="1.6.2924" targetFramework="net462" />
+  <package id="SFA.DAS.Account.Api.Types" version="1.6.2924" targetFramework="net462" />
+  <package id="SFA.DAS.Common.Domain" version="1.4.278" targetFramework="net462" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net462" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net462" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net462" />

--- a/src/SFA.DAS.Forecasting.Functions.Framework/SFA.DAS.Forecasting.Functions.Framework.csproj
+++ b/src/SFA.DAS.Forecasting.Functions.Framework/SFA.DAS.Forecasting.Functions.Framework.csproj
@@ -84,6 +84,9 @@
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\packages\NLog.4.4.12\lib\net45\NLog.dll</HintPath>
     </Reference>
+    <Reference Include="SFA.DAS.Common.Domain, Version=1.4.278.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Common.Domain.1.4.278\lib\net462\SFA.DAS.Common.Domain.dll</HintPath>
+    </Reference>
     <Reference Include="SFA.DAS.Configuration, Version=1.0.0.53229, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Configuration.1.0.0.53229\lib\net45\SFA.DAS.Configuration.dll</HintPath>
     </Reference>
@@ -94,10 +97,10 @@
       <HintPath>..\packages\SFA.DAS.Configuration.FileStorage.1.0.0.49931\lib\net45\SFA.DAS.Configuration.FileStorage.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.EAS.Account.Api.Client, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Account.Api.Client.1.3.1331\lib\net45\SFA.DAS.EAS.Account.Api.Client.dll</HintPath>
+      <HintPath>..\packages\SFA.DAS.Account.Api.Client.1.6.2924\lib\net462\SFA.DAS.EAS.Account.Api.Client.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.EAS.Account.Api.Types, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Account.Api.Types.1.3.1331\lib\net45\SFA.DAS.EAS.Account.Api.Types.dll</HintPath>
+      <HintPath>..\packages\SFA.DAS.Account.Api.Types.1.6.2924\lib\net462\SFA.DAS.EAS.Account.Api.Types.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.HashingService, Version=1.0.0.57835, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.HashingService.1.0.0.57835\lib\net45\SFA.DAS.HashingService.dll</HintPath>

--- a/src/SFA.DAS.Forecasting.Functions.Framework/packages.config
+++ b/src/SFA.DAS.Forecasting.Functions.Framework/packages.config
@@ -21,8 +21,9 @@
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net462" />
   <package id="NLog" version="4.4.12" targetFramework="net462" />
-  <package id="SFA.DAS.Account.Api.Client" version="1.3.1331" targetFramework="net462" />
-  <package id="SFA.DAS.Account.Api.Types" version="1.3.1331" targetFramework="net462" />
+  <package id="SFA.DAS.Account.Api.Client" version="1.6.2924" targetFramework="net462" />
+  <package id="SFA.DAS.Account.Api.Types" version="1.6.2924" targetFramework="net462" />
+  <package id="SFA.DAS.Common.Domain" version="1.4.278" targetFramework="net462" />
   <package id="SFA.DAS.Configuration" version="1.0.0.53229" targetFramework="net462" />
   <package id="SFA.DAS.Configuration.AzureTableStorage" version="1.0.0.53229" targetFramework="net462" />
   <package id="SFA.DAS.Configuration.FileStorage" version="1.0.0.49931" targetFramework="net462" />

--- a/src/SFA.DAS.Forecasting.Payments.Functions/SFA.DAS.Forecasting.Payments.Functions.csproj
+++ b/src/SFA.DAS.Forecasting.Payments.Functions/SFA.DAS.Forecasting.Payments.Functions.csproj
@@ -11,7 +11,8 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.ServiceBus" Version="2.3.0" />    
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.31" />    
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />    
-    <PackageReference Include="SFA.DAS.Account.Api.Types" Version="1.3.1331" />    
+    <PackageReference Include="SFA.DAS.Account.Api.Client" Version="1.6.2924" />    
+    <PackageReference Include="SFA.DAS.Account.Api.Types" Version="1.6.2924" />    
     <PackageReference Include="SFA.DAS.HashingService" Version="1.0.0.43004" />    
     <PackageReference Include="SFA.DAS.NLog.Logger" Version="1.0.0.47445" />    
     <PackageReference Include="SFA.DAS.NLog.Targets.Redis" Version="1.0.0.47445" />    

--- a/src/SFA.DAS.Forecasting.StubApi.Functions/SFA.DAS.Forecasting.StubApi.Functions.csproj
+++ b/src/SFA.DAS.Forecasting.StubApi.Functions/SFA.DAS.Forecasting.StubApi.Functions.csproj
@@ -6,8 +6,8 @@
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.31" />
     <PackageReference Include="Bogus" Version="22.0.8" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="SFA.DAS.Account.Api.Client" Version="1.3.1331" />
-    <PackageReference Include="SFA.DAS.Account.Api.Types" Version="1.3.1331" />
+    <PackageReference Include="SFA.DAS.Account.Api.Client" Version="1.6.2924" />
+    <PackageReference Include="SFA.DAS.Account.Api.Types" Version="1.6.2924" />
     <PackageReference Include="SFA.DAS.Commitments.Api.Types" Version="2.1.511" />
     <PackageReference Include="SFA.DAS.Provider.Events.Api.Client" Version="2.1.30" />
     <PackageReference Include="WindowsAzure.Storage" Version="8.7.0" />

--- a/src/SFA.DAS.Forecasting.Web/SFA.DAS.Forecasting.Web.csproj
+++ b/src/SFA.DAS.Forecasting.Web/SFA.DAS.Forecasting.Web.csproj
@@ -185,6 +185,9 @@
     <Reference Include="SFA.DAS.Authorization, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Authorization.6.0.52\lib\net462\SFA.DAS.Authorization.dll</HintPath>
     </Reference>
+    <Reference Include="SFA.DAS.Common.Domain, Version=1.4.278.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Common.Domain.1.4.278\lib\net462\SFA.DAS.Common.Domain.dll</HintPath>
+    </Reference>
     <Reference Include="SFA.DAS.Configuration, Version=1.0.0.53229, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Configuration.1.0.0.53229\lib\net45\SFA.DAS.Configuration.dll</HintPath>
     </Reference>
@@ -196,10 +199,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="SFA.DAS.EAS.Account.Api.Client, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Account.Api.Client.1.3.1331\lib\net45\SFA.DAS.EAS.Account.Api.Client.dll</HintPath>
+      <HintPath>..\packages\SFA.DAS.Account.Api.Client.1.6.2924\lib\net462\SFA.DAS.EAS.Account.Api.Client.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.EAS.Account.Api.Types, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Account.Api.Types.1.3.1331\lib\net45\SFA.DAS.EAS.Account.Api.Types.dll</HintPath>
+      <HintPath>..\packages\SFA.DAS.Account.Api.Types.1.6.2924\lib\net462\SFA.DAS.EAS.Account.Api.Types.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.EmployerFinance.Types, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.EmployerFinance.Types.0.2.24\lib\netstandard2.0\SFA.DAS.EmployerFinance.Types.dll</HintPath>

--- a/src/SFA.DAS.Forecasting.Web/packages.config
+++ b/src/SFA.DAS.Forecasting.Web/packages.config
@@ -64,9 +64,10 @@
   <package id="RazorGenerator.Mvc" version="2.4.9" targetFramework="net462" />
   <package id="Respond" version="1.2.0" targetFramework="net462" />
   <package id="Scrutor" version="3.1.0" targetFramework="net462" />
-  <package id="SFA.DAS.Account.Api.Client" version="1.3.1331" targetFramework="net462" />
-  <package id="SFA.DAS.Account.Api.Types" version="1.3.1331" targetFramework="net462" />
+  <package id="SFA.DAS.Account.Api.Client" version="1.6.2924" targetFramework="net462" />
+  <package id="SFA.DAS.Account.Api.Types" version="1.6.2924" targetFramework="net462" />
   <package id="SFA.DAS.Authorization" version="6.0.52" targetFramework="net462" />
+  <package id="SFA.DAS.Common.Domain" version="1.4.278" targetFramework="net462" />
   <package id="SFA.DAS.Configuration" version="1.0.0.53229" targetFramework="net462" />
   <package id="SFA.DAS.Configuration.AzureTableStorage" version="1.0.0.53229" targetFramework="net462" />
   <package id="SFA.DAS.Configuration.FileStorage" version="1.0.0.49931" targetFramework="net462" />


### PR DESCRIPTION
…date version of newtonsoft, referenced that new package version within this application. This resolved an issue when creating account projections with incompatible versions of newtonsoft referenced in the application versus in the AccountApiClient dependency